### PR TITLE
Dynamic book config

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1210,6 +1210,7 @@ dependencies = [
  "mockall_double",
  "serde",
  "serde_json",
+ "temp-env",
  "tempfile",
  "tera",
  "toml",
@@ -2115,6 +2116,15 @@ dependencies = [
  "proc-macro2",
  "quote",
  "unicode-ident",
+]
+
+[[package]]
+name = "temp-env"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a30d48359f77fbb6af3d7b928cc2d092e1dc90b44f397e979ef08ae15733ed65"
+dependencies = [
+ "once_cell",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,6 +23,7 @@ mdbook-epub = { git = "https://github.com/dieterplex/mdbook-epub", rev = "c92696
 mockall_double = "0.3.0"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
+temp-env = "0.3"
 tera = "1"
 toml = "0.5.0"
 url = "2.3"

--- a/README.md
+++ b/README.md
@@ -20,6 +20,8 @@ working-dir = "tmp"
 [[book]]
 repo-url = "https://github.com/rust-lang/book.git"
 url = "https://doc.rust-lang.org/stable/book/index.html"
+[book.env-var]
+MDBOOK_PREPROCESSOR__NOCOMMENT = ""
 
 [[book]]
 repo-url = "https://github.com/rust-lang/rust-by-example.git"
@@ -29,6 +31,13 @@ url = "https://doc.rust-lang.org/stable/rust-by-example/"
 repo-url = "https://github.com/rust-lang-nursery/rust-cookbook.git"
 url = "https://github.com/rust-lang-nursery/rust-cookbook"
 ```
+
+### Preprocessing
+
+mdBook build-in preprocessors is enabled tranparently and is affected by book.yaml per Book if there is any.
+If you want to filter with custom preprocessors, using book.env-var, like the conf above, to specify special [enviroment variables](https://rust-lang.github.io/mdBook/format/configuration/environment-variables.html) that could be accepted by mdBook.
+And don't forget to install preprocessors before building your bookshelf, or it would just generate books without these preprocessors.
+
 
 ## Usage
 

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -73,7 +73,7 @@ fn test_run() {
     ctx_book
         .expect()
         .once()
-        .return_once(move |_path, _dest| Ok(book_result));
+        .return_once(move |_path, _vars, _dest| Ok(book_result));
 
     let got = super::run(&config).unwrap();
 

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -20,8 +20,11 @@ fn test_run() {
     templates-dir = "tests/templates"
 
     [[book]]
+    title = "Hello Rust"
     repo-url = "{REPO_URL}"
     url = "https://rams3s.github.io/mdbook-dummy/index.html"
+    [book.env-var]
+    MDBOOK_PREPROCESSOR__X = ""
     "#
     ))
     .unwrap();
@@ -73,7 +76,14 @@ fn test_run() {
     ctx_book
         .expect()
         .once()
-        .return_once(move |_path, _vars, _dest| Ok(book_result));
+        .return_once(move |_path, vars, _dest| {
+            assert_eq!(vars.len(), 2);
+            assert_eq!(vars[0].0, "MDBOOK_PREPROCESSOR__X");
+            assert_eq!(vars[0].1, Some(String::from("\"\"")));
+            assert_eq!(vars[1].0, "MDBOOK_BOOK__TITLE");
+            assert_eq!(&vars[1].1, &book_result.0);
+            Ok(book_result)
+        });
 
     let got = super::run(&config).unwrap();
 


### PR DESCRIPTION
This changeset add a way to preprocess a book or to update any config *without touching* `book.toml`. The primary goal here is to customize a book on the fly by changing book.toml dynamically. Specifically, we need to fix errors of books using preprocessors.

There is a feature,  [Environment Variables](
https://rust-lang.github.io/mdBook/format/configuration/environment-variables.html), of mdBook to generate a book with dynamic config. Here we propose the key-value pairs under `book.env-var` like below to utilize this feature:

```toml
# bookshelf.toml
[[book]]
repo-url = "https://github.com/rust-lang/book.git"
url = "https://doc.rust-lang.org/stable/book/"
# It's like to add `[preprocessor.nocomment]` to book.toml
[book.env-var]
MDBOOK_PREPROCESSOR__NOCOMMENT = ""
```

Internally this feature require using an API from mdBook (`MDBook::execute_build_process` in https://github.com/dieterplex/mdbook-epub/commit/ea1f88093c2833518d79d032103fc345c4a821e6#) to read env vars into config and to run preprocessors.

- [ ] Update doc
- [ ] Add tests
